### PR TITLE
clang-format warnings are treated as errors

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -97,7 +97,8 @@ class KinectAzureSensorSDKConan(ConanFile):
         cmake.parallel = False ## seems that not all internal dependencies are specified correctly..
         
         cmake.configure(build_folder=self.build_subfolder)
-        cmake.build(target='clangformat') 
+        if shutil.which('clang-format'):
+            cmake.build(target='clangformat') 
         cmake.build()
         cmake.install()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -97,6 +97,7 @@ class KinectAzureSensorSDKConan(ConanFile):
         cmake.parallel = False ## seems that not all internal dependencies are specified correctly..
         
         cmake.configure(build_folder=self.build_subfolder)
+        cmake.build(target='clangformat') 
         cmake.build()
         cmake.install()
 


### PR DESCRIPTION
and is therefore a build-blocker. This only affects machines where clang-format is installed-because this task is skipped otherwise.

Solution: just reformat the entire codebase to prevent this from happening before calling `cmake.build()` 